### PR TITLE
Remove miniconda link from top bar.

### DIFF
--- a/conda_sphinx_theme/_templates/navbar_center.html
+++ b/conda_sphinx_theme/_templates/navbar_center.html
@@ -1,12 +1,9 @@
 <ul id="navbar-main-elements" class="navbar-nav">
     <li class="nav-item {% if project == "conda" %}current active{% endif %}">
-        <a class="reference internal nav-link" href="https://docs.conda.io/projects/conda/">Conda</a>
+        <a class="reference internal nav-link" href="https://docs.conda.io/projects/conda/">conda</a>
     </li>
     <li class="nav-item {% if project == "conda-build" %}current active{% endif %}">
-        <a class="reference internal nav-link" href="https://docs.conda.io/projects/conda-build">Conda-build</a>
-    </li>
-    <li class="nav-item">
-        <a class="reference nav-external nav-link" href="https://docs.anaconda.com/free/miniconda/">Miniconda</a>
+        <a class="reference internal nav-link" href="https://docs.conda.io/projects/conda-build">conda-build</a>
     </li>
     <li class="nav-item">
         <a class="reference nav-external nav-link" href="https://conda.org">conda.org</a>


### PR DESCRIPTION
This removes the miniconda link, since we have better elaboration on the conda docs landing page which installer to use.