### PR TITLE
Combine duplicate goatcounter urls

### DIFF
--- a/conda_sphinx_theme/_templates/footer_center.html
+++ b/conda_sphinx_theme/_templates/footer_center.html
@@ -1,5 +1,5 @@
-{% if goatcounter_dashboard_url %}
-<a href="{{ goatcounter_dashboard_url }}" title="Analytics Dashboard">
+{% if theme_goatcounter_url %}
+<a href="{{ theme_goatcounter_url }}" title="Analytics Dashboard">
     Analytics Dashboard <i class="fa-solid fa-arrow-up-right-from-square"></i>
 </a>
 {% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,10 +59,6 @@ html_theme_options = {
     ],
 }
 
-html_context = {
-    "goatcounter_dashboard_url": ""  # Link to your GoatCounter dashboard
-}
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
Extracted from #28

Defining both `html_theme_options.goatcounter_url` and `html_context.goatcounter_dashboard_url` is redundant since the theme options are automatically accessible in the templates:

> The `[options]` table defines the options for the theme. It is structured such that each key-value pair corresponds to a variable name and the corresponding default value. These options can be overridden by the user in [`html_theme_options`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme_options) and are accessible from all templates as `theme_<name>`.

https://www.sphinx-doc.org/en/master/development/html_themes/index.html#theme-configuration-theme-toml