### PR TITLE
Use `pydata_sphinx_theme.utils.get_theme_options_dict`

### DIFF
--- a/conda_sphinx_theme/__init__.py
+++ b/conda_sphinx_theme/__init__.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+from pydata_sphinx_theme.utils import get_theme_options_dict
+
 try:
     from ._version import version_tuple as version_info, __version__  # noqa: F401  # ty: ignore[unresolved-import]
 except ImportError:
@@ -5,17 +9,10 @@ except ImportError:
     __version__ = "0.0.0+unknown"
     version_info = (0, 0, 0)
 
-from pathlib import Path
-
 
 def set_config_defaults(app):
     """Set default logo in theme options."""
-    try:
-        theme = app.builder.theme_options
-    except AttributeError:
-        theme = None
-    if not theme:
-        theme = {}
+    theme = get_theme_options_dict(app)
 
     # Add custom Zulip icon
     app.add_js_file("js/zulip-icon.js")
@@ -39,9 +36,6 @@ def set_config_defaults(app):
     favicons = theme.get("favicons", [])
     favicons.append({"href": "favicon.ico", "rel": "icon", "type": "image/svg+xml"})
     theme["favicons"] = favicons
-
-    # Update the HTML theme config
-    app.builder.theme_options = theme
 
 
 # For more details, see:

--- a/conda_sphinx_theme/__init__.py
+++ b/conda_sphinx_theme/__init__.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
 
 def set_config_defaults(app):
     """Inject additional default theme options and icon links."""
-    theme = get_theme_options_dict(app)
+    theme = get_theme_options_dict(app) or {}
 
     # Add extra icon links entries if there were shortcuts present
     # See https://github.com/pydata/pydata-sphinx-theme/blob/6b426bb133812c69b33ce88913f8bc018f1bfd02/src/pydata_sphinx_theme/__init__.py#L141-L163
@@ -54,6 +54,9 @@ def set_config_defaults(app):
     favicons = theme.get("favicons", [])
     favicons.append({"href": "favicon.ico", "rel": "icon", "type": "image/svg+xml"})
     theme["favicons"] = favicons
+
+    # Update the HTML theme config
+    app.builder.theme_options = theme
 
 
 # For more details, see:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -78,7 +78,7 @@ def test_set_config_defaults_with_goatcounter(mocker):
     set_config_defaults(app)
 
     # Verify GoatCounter script was added with correct parameters
-    calls = [call for call in app.add_js_file.call_args_list 
+    calls = [call for call in app.add_js_file.call_args_list
              if len(call[0]) > 0 and call[0][0] == "js/count.js"]
     assert len(calls) == 1
     assert calls[0][1]["data-goatcounter"] == "https://example.goatcounter.com/count"
@@ -98,7 +98,7 @@ def test_set_config_defaults_without_goatcounter(mocker):
     set_config_defaults(app)
 
     # Verify GoatCounter script was NOT added
-    calls = [call for call in app.add_js_file.call_args_list 
+    calls = [call for call in app.add_js_file.call_args_list
              if len(call[0]) > 0 and call[0][0] == "js/count.js"]
     assert len(calls) == 0
 
@@ -175,36 +175,3 @@ def test_set_config_defaults_appends_to_existing_favicons(mocker):
     assert len(favicons) == 2
     assert favicons[0]["href"] == "custom.png"
     assert favicons[1]["href"] == "favicon.ico"
-
-
-def test_set_config_defaults_handles_missing_builder_theme_options(mocker):
-    """Test set_config_defaults when builder has no theme_options attribute."""
-    from conda_sphinx_theme import set_config_defaults
-
-    app = mocker.Mock()
-    app.builder = mocker.Mock(spec=[])  # No theme_options attribute
-
-    # Should not raise
-    set_config_defaults(app)
-
-    # Verify default settings were still applied
-    assert hasattr(app.builder, "theme_options")
-    assert "logo" in app.builder.theme_options
-    assert "favicons" in app.builder.theme_options
-
-
-def test_set_config_defaults_handles_none_theme_options(mocker):
-    """Test set_config_defaults when theme_options is None."""
-    from conda_sphinx_theme import set_config_defaults
-
-    app = mocker.Mock()
-    app.builder = mocker.Mock()
-    app.builder.theme_options = None
-
-    # Should not raise
-    set_config_defaults(app)
-
-    # Verify default settings were applied
-    assert app.builder.theme_options is not None
-    assert "logo" in app.builder.theme_options
-    assert "favicons" in app.builder.theme_options

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -185,7 +185,7 @@ def test_set_config_defaults_appends_to_existing_favicons(mocker):
     assert favicons[0]["href"] == "custom.png"
     assert favicons[1]["href"] == "favicon.ico"
 
-    
+
 def test_set_config_defaults_handles_missing_builder_theme_options(mocker):
     """Test set_config_defaults when builder has no theme_options attribute."""
     from conda_sphinx_theme import set_config_defaults


### PR DESCRIPTION
Use the `pydata_sphinx_theme.utils.get_theme_options_dict` instead of manually fetching/monkeypatching a potentially missing dict.

Ref: https://pydata-sphinx-theme.readthedocs.io/en/stable/api/pydata_sphinx_theme/utils/index.html#pydata_sphinx_theme.utils.get_theme_options_dict