### PR TITLE
Improve how default `icon_links` are added

### DIFF
--- a/conda_sphinx_theme/__init__.py
+++ b/conda_sphinx_theme/__init__.py
@@ -1,6 +1,6 @@
 try:
     from ._version import version_tuple as version_info, __version__  # noqa: F401  # ty: ignore[unresolved-import]
-except ImportError:
+except ImportError:  # pragma: no cover
     # Version file not generated yet (e.g., in editable install before build)
     __version__ = "0.0.0+unknown"
     version_info = (0, 0, 0)
@@ -20,7 +20,7 @@ def set_config_defaults(app):
     # Add extra icon links entries if there were shortcuts present
     # See https://github.com/pydata/pydata-sphinx-theme/blob/6b426bb133812c69b33ce88913f8bc018f1bfd02/src/pydata_sphinx_theme/__init__.py#L141-L163
     icon_links = []
-    for key, default_url, name, icon in [
+    for key, default_url, icon, name in [
         ("zulip_url", "https://conda.zulipchat.com/", "fa-custom fa-zulip", "Zulip"),
     ]:
         # Skip link if URL is falsy

--- a/conda_sphinx_theme/__init__.py
+++ b/conda_sphinx_theme/__init__.py
@@ -9,13 +9,31 @@ from pathlib import Path
 
 
 def set_config_defaults(app):
-    """Set default logo in theme options."""
+    """Inject additional default theme options and icon links."""
     try:
         theme = app.builder.theme_options
     except AttributeError:
         theme = None
     if not theme:
         theme = {}
+
+    # Add extra icon links entries if there were shortcuts present
+    # See https://github.com/pydata/pydata-sphinx-theme/blob/6b426bb133812c69b33ce88913f8bc018f1bfd02/src/pydata_sphinx_theme/__init__.py#L141-L163
+    icon_links = []
+    for key, default_url, name, icon in [
+        ("zulip_url", "https://conda.zulipchat.com/", "fa-custom fa-zulip", "Zulip"),
+    ]:
+        # Skip link if URL is falsy
+        if url := theme.get(key, default_url):
+            icon_links.append(
+                {
+                    "url": url,
+                    "icon": icon,
+                    "name": name,
+                    "type": "fontawesome",
+                },
+            )
+    theme["icon_links"] = [*icon_links, *(theme.get("icon_links") or [])]
 
     # Add custom Zulip icon
     app.add_js_file("js/zulip-icon.js")

--- a/conda_sphinx_theme/_templates/conda_icon_links.html
+++ b/conda_sphinx_theme/_templates/conda_icon_links.html
@@ -1,7 +1,0 @@
-{%- if not theme_icon_links -%}
-  {%- set theme_icon_links = [
-    {"name": "GitHub", "url": "https://github.com/conda/conda", "icon": "fa-brands fa-square-github", "type": "fontawesome"},
-    {"name": "Zulip", "url": "https://conda.zulipchat.com", "icon": "fa-custom fa-zulip", "type": "fontawesome"},
-  ] -%}
-{%- endif -%}
-{% extends "navbar-icon-links.html" %}

--- a/conda_sphinx_theme/theme.conf
+++ b/conda_sphinx_theme/theme.conf
@@ -6,7 +6,7 @@ sidebars = _templates/sidebar-nav-bs.html
 [options]
 # navbar_links = absolute
 navbar_center = _templates/navbar_center.html
-navbar_end = theme-switcher.html, _templates/conda_icon_links.html
 footer_center = _templates/footer_center.html
 favicons = static/favicon.ico
 goatcounter_url = ""
+zulip_url = ""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,14 +49,6 @@ html_theme_options = {
     "show_prev_next": False,
     "github_url": "https://github.com/conda-incubator/conda-sphinx-theme",
     "goatcounter_url": "",  # Disabled by default; put your own GoatCounter URL here to enable
-    "icon_links": [
-        {
-            "name": "Zulip",
-            "url": "https://conda.zulipchat.com",
-            "icon": "fa-custom fa-zulip",
-            "type": "fontawesome",
-        },
-    ],
 }
 
 html_context = {

--- a/pixi.lock
+++ b/pixi.lock
@@ -6,6 +6,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/label/ty_alpha/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -267,6 +269,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/label/ty_alpha/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -603,6 +607,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/label/ty_alpha/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -898,6 +904,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/label/ty_alpha/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1197,6 +1205,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/label/ty_alpha/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1496,6 +1506,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/label/ty_alpha/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1796,6 +1808,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/label/ty_alpha/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3169,13 +3183,12 @@ packages:
   timestamp: 1733218222191
 - pypi: ./
   name: conda-sphinx-theme
-  version: 0.3.1.dev37+g60e040904.d20251027
-  sha256: d8403901f4e7123cf041ce6ec86060a1dd1f6606dbeec41775ed26bb8609af47
+  version: 0.4.1.dev2+g564279406
+  sha256: 98e239653d0919cdcf98b3333cc145fbf9f9d20d9507bd602e9ba4757a189e91
   requires_dist:
   - pydata-sphinx-theme>=0.15
   - sphinx-favicon
   requires_python: '>=3.9'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.10.4-py39heb7d2ae_0.conda
   sha256: c461bb1afa582d9e6b14e857bcdf938271ba34735db8e2c5ef131760250f5761
   md5: 3ecc156a987ea09c920564f1a2e03963

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
-    {name = "Travs Hathaway"},
+    {name = "Travis Hathaway"},
 ]
 classifiers = [
     "Framework :: Sphinx :: Theme",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,15 @@
 Tests for the main conda_sphinx_theme module.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from typing import Literal, Optional
+
 
 def test_module_imports():
     """Test that the main module can be imported without errors."""
@@ -78,7 +87,7 @@ def test_set_config_defaults_with_goatcounter(mocker):
     set_config_defaults(app)
 
     # Verify GoatCounter script was added with correct parameters
-    calls = [call for call in app.add_js_file.call_args_list 
+    calls = [call for call in app.add_js_file.call_args_list
              if len(call[0]) > 0 and call[0][0] == "js/count.js"]
     assert len(calls) == 1
     assert calls[0][1]["data-goatcounter"] == "https://example.goatcounter.com/count"
@@ -98,7 +107,7 @@ def test_set_config_defaults_without_goatcounter(mocker):
     set_config_defaults(app)
 
     # Verify GoatCounter script was NOT added
-    calls = [call for call in app.add_js_file.call_args_list 
+    calls = [call for call in app.add_js_file.call_args_list
              if len(call[0]) > 0 and call[0][0] == "js/count.js"]
     assert len(calls) == 0
 
@@ -208,3 +217,34 @@ def test_set_config_defaults_handles_none_theme_options(mocker):
     assert app.builder.theme_options is not None
     assert "logo" in app.builder.theme_options
     assert "favicons" in app.builder.theme_options
+
+@pytest.mark.parametrize(
+    "zulip_url",
+    [
+        pytest.param(None, id="unset"),
+        pytest.param(False, id="falsy"),
+        pytest.param("https://custom.url.com", id="truthy"),
+    ]
+)
+def test_set_config_defaults_adds_icon_links(mocker, zulip_url: Optional[str | Literal[False]]):
+    """Test that set_config_defaults adds icon links."""
+    from conda_sphinx_theme import set_config_defaults
+
+    app = mocker.Mock()
+    app.builder = mocker.Mock()
+    app.builder.theme_options = theme_options = {}
+
+    if zulip_url is not None:
+        theme_options["zulip_url"] = zulip_url
+
+    set_config_defaults(app)
+
+    # Verify icon links were added
+    icon_links = app.builder.theme_options["icon_links"]
+    if zulip_url is False:
+        assert not icon_links
+    else:
+        assert len(icon_links) == 1
+        assert icon_links[0]["name"] == "Zulip"
+    if zulip_url:
+        assert icon_links[0]["url"] == zulip_url


### PR DESCRIPTION
Pulled from #28

Improves how default icon links/shortcuts are injected (mirroring what pydata-sphinx-theme does). Allows us to remove a custom template.